### PR TITLE
Update the suggestion approval path

### DIFF
--- a/prisma/migrations/20260115000010_add_processing_and_failed_status/migration.sql
+++ b/prisma/migrations/20260115000010_add_processing_and_failed_status/migration.sql
@@ -1,0 +1,12 @@
+-- AlterEnum
+ALTER TYPE "GymImageStatus" ADD VALUE IF NOT EXISTS 'PROCESSING';
+ALTER TYPE "GymImageStatus" ADD VALUE IF NOT EXISTS 'FAILED';
+
+-- AlterTable
+ALTER TABLE "ImageQueue" ADD COLUMN "gymImageId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ImageQueue_gymImageId_idx" ON "ImageQueue"("gymImageId");
+
+-- AddForeignKey
+ALTER TABLE "ImageQueue" ADD CONSTRAINT "ImageQueue_gymImageId_fkey" FOREIGN KEY ("gymImageId") REFERENCES "GymEquipmentImage"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,9 +40,11 @@ enum ImageJobStatus {
 
 enum GymImageStatus {
   PENDING
+  PROCESSING
   APPROVED
   REJECTED
   QUARANTINED
+  FAILED
 }
 
 enum EmbeddingScopeType {
@@ -832,6 +834,7 @@ model GymEquipmentImage {
   embeddings     ImageEmbedding[]
   trainingCandidates TrainingCandidate[] @relation("ImageTrainingCandidates")
   globalSuggestions GlobalImageSuggestion[]
+  queueJobs        ImageQueue[]
 
   @@unique([gymId, equipmentId, imageId])
   @@index([gymId, equipmentId])
@@ -885,6 +888,7 @@ model ImageEmbedding {
 model ImageQueue {
   id          String         @id @default(cuid())
   imageId     String?        // for GLOBAL jobs (promotion)
+  gymImageId  String?
   storageKey  String?        // for GYM jobs (finalize)
   jobType     String
   status      ImageJobStatus @default(pending)
@@ -897,13 +901,15 @@ model ImageQueue {
   createdAt   DateTime       @default(now())
   updatedAt   DateTime       @updatedAt
 
-  image EquipmentImage? @relation(fields: [imageId], references: [id], onDelete: Cascade)
+  image     EquipmentImage?    @relation(fields: [imageId], references: [id], onDelete: Cascade)
+  gymImage  GymEquipmentImage? @relation(fields: [gymImageId], references: [id], onDelete: Cascade)
 
   @@index([finishedAt, status])
   @@index([status, priority, scheduledAt])
   @@index([jobType, status])
   @@index([imageId])
   @@index([storageKey])
+  @@index([gymImageId])
 }
 
 // Single-row lease table to coordinate burst workers

--- a/src/modules/equipment/equipment-suggestion.service.ts
+++ b/src/modules/equipment/equipment-suggestion.service.ts
@@ -356,7 +356,25 @@ export class EquipmentSuggestionService {
           await queueImageProcessingForStorageKey({
             prisma: this.prisma,
             storageKey: gymImage.storageKey ?? gymStorageKey,
+            gymImageId: gymImage.id,
             source: 'gym_manager',
+          });
+          await this.prisma.gymEquipmentImage.update({
+            where: { id: gymImage.id },
+            data: { status: 'PROCESSING' },
+          });
+        } else {
+          await this.prisma.gymEquipmentImage.update({
+            where: { id: gymImage.id },
+            data: {
+              status: 'APPROVED',
+              approvedAt: gymImage.approvedAt ?? new Date(),
+              ...(gymImage.approvedByUserId
+                ? {}
+                : suggestion.managerUserId
+                  ? { approvedByUserId: suggestion.managerUserId }
+                  : {}),
+            },
           });
         }
         gymImageId = gymImage.id;

--- a/src/modules/gym/gym.dto.ts
+++ b/src/modules/gym/gym.dto.ts
@@ -193,9 +193,11 @@ export class UpdateGymEquipmentDto {
 
 export enum GymImageStatusDto {
   PENDING = 'PENDING',
+  PROCESSING = 'PROCESSING',
   APPROVED = 'APPROVED',
   REJECTED = 'REJECTED',
   QUARANTINED = 'QUARANTINED',
+  FAILED = 'FAILED',
 }
 
 export class UploadGymImageDto {
@@ -214,7 +216,7 @@ export class UploadGymImageDto {
 
   @IsOptional()
   @IsEnum(GymImageStatusDto, {
-    message: 'status must be PENDING | APPROVED | REJECTED | QUARANTINED',
+    message: 'status must be PENDING | PROCESSING | APPROVED | REJECTED | QUARANTINED | FAILED',
   })
   status?: GymImageStatusDto;
 }

--- a/src/modules/gym/gym.resolvers.ts
+++ b/src/modules/gym/gym.resolvers.ts
@@ -64,6 +64,18 @@ export const GymResolvers = {
       src.capturedAt ?? src.updatedAt ?? new Date(0).toISOString(),
     createdAt: (src: { capturedAt?: string; updatedAt?: string }) =>
       src.capturedAt ?? src.updatedAt ?? new Date(0).toISOString(),
+    status: (src: any) => {
+      if (
+        src.status === 'PENDING' &&
+        src.nsfwScore != null &&
+        src.modelVendor &&
+        src.modelName &&
+        src.modelVersion
+      ) {
+        return 'APPROVED';
+      }
+      return src.status;
+    },
     thumbUrl: async (
       src: { storageKey: string },
       args: { ttlSec?: number },

--- a/src/modules/gym/gym.schema.ts
+++ b/src/modules/gym/gym.schema.ts
@@ -1,5 +1,5 @@
 export const gymTypeDefs = `
-  enum GymImageStatus { PENDING APPROVED REJECTED QUARANTINED }
+  enum GymImageStatus { PENDING PROCESSING APPROVED REJECTED QUARANTINED FAILED }
 
   type Gym {
     id: Int!

--- a/src/modules/gym/gym.service.ts
+++ b/src/modules/gym/gym.service.ts
@@ -569,6 +569,7 @@ export class GymService {
         status: ImageJobStatus.pending,
         priority,
         storageKey: approvedKey,
+        gymImageId: image.id,
       },
     });
 

--- a/src/modules/gym/gym.types.ts
+++ b/src/modules/gym/gym.types.ts
@@ -106,7 +106,13 @@ export interface UpdateGymEquipmentInput {
   note?: string;
 }
 
-export type GymImageStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'QUARANTINED';
+export type GymImageStatus =
+  | 'PENDING'
+  | 'PROCESSING'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'QUARANTINED'
+  | 'FAILED';
 
 export interface UploadGymImageInput {
   gymId: number;

--- a/src/modules/images/image-intake.service.ts
+++ b/src/modules/images/image-intake.service.ts
@@ -199,6 +199,7 @@ export class ImageIntakeService {
             status: ImageJobStatus.pending,
             priority,
             storageKey: approvedKey,
+            gymImageId: image.id,
           },
         ];
     if (jobs.length) {
@@ -450,6 +451,7 @@ export class ImageIntakeService {
               status: ImageJobStatus.pending,
               priority,
               storageKey: approvedKey,
+              gymImageId: image.id,
             },
           ];
       if (jobs.length) {

--- a/src/modules/images/image-promotion.service.ts
+++ b/src/modules/images/image-promotion.service.ts
@@ -610,6 +610,7 @@ export class ImagePromotionService {
         await queueImageProcessingForStorageKey({
           prisma: this.prisma,
           storageKey: suggestion.gymImage.storageKey,
+          gymImageId: suggestion.gymImageId ?? undefined,
           source: 'gym_manager',
         });
       }

--- a/src/modules/images/image-queue.helpers.ts
+++ b/src/modules/images/image-queue.helpers.ts
@@ -7,19 +7,25 @@ type QueueSource = 'recognition_user' | 'gym_manager' | 'admin' | 'backfill' | '
 export async function queueImageProcessingForStorageKey({
   prisma,
   storageKey,
+  gymImageId,
   source = 'gym_manager',
 }: {
   prisma: PrismaClient;
   storageKey: string | null | undefined;
+  gymImageId?: string | null;
   source?: QueueSource;
 }) {
   const key = storageKey?.trim();
-  if (!key) return false;
+  if (!key && !gymImageId) return false;
+
+  const orClauses = [] as { storageKey?: string; gymImageId?: string }[];
+  if (key) orClauses.push({ storageKey: key });
+  if (gymImageId) orClauses.push({ gymImageId });
 
   const existing = await prisma.imageQueue.findFirst({
     where: {
-      storageKey: key,
       status: { in: [ImageJobStatus.pending, ImageJobStatus.processing] },
+      ...(orClauses.length ? { OR: orClauses } : {}),
     },
     select: { id: true },
   });
@@ -30,7 +36,8 @@ export async function queueImageProcessingForStorageKey({
       jobType: 'HASH',
       status: ImageJobStatus.pending,
       priority: priorityFromSource(source),
-      storageKey: key,
+      storageKey: key ?? undefined,
+      gymImageId: gymImageId ?? undefined,
     },
   });
 

--- a/src/modules/images/queue-runner.service.ts
+++ b/src/modules/images/queue-runner.service.ts
@@ -3,7 +3,7 @@ import type { ImageQueue, PrismaClient } from '../../prisma';
 
 export type QueueJob = Pick<
   ImageQueue,
-  'id' | 'jobType' | 'storageKey' | 'imageId' | 'attempts' | 'priority'
+  'id' | 'jobType' | 'storageKey' | 'imageId' | 'gymImageId' | 'attempts' | 'priority'
 >;
 
 const RUNNER_NAME = 'image-runner';
@@ -72,7 +72,7 @@ export class QueueRunnerService {
           "attempts" = "attempts" + 1
       FROM next
       WHERE q."id" = next."id"
-      RETURNING q."id", q."jobType", q."storageKey", q."imageId", q."attempts", q."priority";
+      RETURNING q."id", q."jobType", q."storageKey", q."imageId", q."gymImageId", q."attempts", q."priority";
     `,
       batchSize,
     );


### PR DESCRIPTION
Extended GymImageStatus with PROCESSING/FAILED states, linked ImageQueue rows to gym images, and added a migration to evolve the enum and queue schema accordingly.

Updated the suggestion approval path to copy images into gym-approved storage, reset candidate flags, adjust statuses, and enqueue processing jobs with the associated gym image id.

Propagated gym image ids through queue helpers, ingestion flows, and the worker so jobs update approval status on success and mark FAILED on terminal errors.

Expanded GraphQL/DTO typings for the new statuses and added a resolver override that surfaces APPROVED once processing metadata exists even if the stored status is still PENDING.